### PR TITLE
Updated project to use dot net framework 4.6.1

### DIFF
--- a/src/FiddlerSanitizer.csproj
+++ b/src/FiddlerSanitizer.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>FiddlerSanitizer</RootNamespace>
     <AssemblyName>FiddlerSanitizer</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">


### PR DESCRIPTION
when attempting to build was warned that the primary reference "Fiddler" could not be resolved as it was built against the dot net framework 4.6.1.  The current project targets dot net framework 4.5.2